### PR TITLE
commented out __all__ in __init__.py to fix import

### DIFF
--- a/pychrm/__init__.py
+++ b/pychrm/__init__.py
@@ -1,6 +1,6 @@
 __version__ = "unknown"
 
-__all__ = [ 'pychrm', 'FeatureSet' ]
+#__all__ = [ 'pychrm', 'FeatureSet' ]
 
 from pychrm import *
 


### PR DESCRIPTION
My first pull request! Without this change, you can't do a "import pychrm" inside a python interpreter. It would raise at import time a AttributeError: 'module' object has no attribute 'ComputationTaskInstances' ... As of right now it's best to just import all modules in the python package rather than just pick and choose which packages consist of **all**.
