### PR TITLE
Pass -threads to swig to release GIL when running Pychrm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ wndchrm_module = Extension('_pychrm',
 		'src/gsl/specfunc.cpp',
 	],
 	include_dirs=['./','src/', '/usr/local/include'],
-	swig_opts=['-c++', '-I./', '-I./src', '-outdir', 'pychrm'],
+	swig_opts=['-threads', '-c++', '-I./', '-I./src', '-outdir', 'pychrm'],
 	libraries=['tiff','fftw3'],
 )
 


### PR DESCRIPTION
Fix wnd-charm/wnd-charm#24

Release the global interpreter lock when calling native Pychrm methods. Note as described in http://swig.10945.n7.nabble.com/How-to-release-Python-GIL-td5027.html this could be optimised to not release the lock for short functions.
