### PR TITLE
Enable print_method_wrapper to output to an existing stream

### DIFF
--- a/pychrm/FeatureSet.py
+++ b/pychrm/FeatureSet.py
@@ -187,6 +187,18 @@ def output_railroad_switch( method_that_prints_output ):
 			retval = method_that_prints_output( *args, **kwargs )
 			sys.stdout.close()
 			sys.stdout = backup
+		elif "output_stream" in kwargs:
+			output_stream = kwargs[ "output_stream" ]
+			del kwargs[ "output_stream" ]
+			print 'Saving output of function "{0}()" to stream'.format(\
+			      method_that_prints_output.__name__)
+			import sys
+			backup = sys.stdout
+			try:
+				sys.stdout = output_stream
+				retval = method_that_prints_output( *args, **kwargs )
+			finally:
+				sys.stdout = backup
 		else:
 			retval = method_that_prints_output( *args, **kwargs )
 		return retval


### PR DESCRIPTION
Add `output_stream` keyword to `print_method_wrapper`, so that output can be directed to an existing stream such as an open file-handle, or `StringIO`.
