### PR TITLE
Housekeeping: git hash in version str, unittest cleanup, et. al

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class CustomInstall(install):
         self.do_egg_install()
 
 import os
-pkg_dir = os.path.join (os.path.dirname(os.path.realpath(__file__)),'wndcharm')
+pkg_dir = os.path.join( os.path.dirname( os.path.realpath(__file__)), 'wndcharm' )
 
 # this sets the __version__ variable
 # the wndcharm/_version.py file contains a single line assigning the __version__ variable
@@ -34,12 +34,19 @@ pkg_dir = os.path.join (os.path.dirname(os.path.realpath(__file__)),'wndcharm')
 execfile(os.path.join (pkg_dir,'_version.py'))
 
 try:
-    import subprocess
-    # If this returns non-zero, throws CalledProcessError
-    git_hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).strip()
+    from subprocess import check_output
+
+    # Get the git hash for this commit
+    # If this returns non-zero, a.k.a. got a git repo, throws CalledProcessError
+    git_hash = check_output(['git', 'rev-parse', '--short', 'HEAD']).strip()
+
+    # Check for local modifications
+    if check_output(['git', 'diff-index', '--name-only', 'HEAD']).strip():
+        git_hash += 'localmod'
+
     print "git hash " + git_hash
-    # this construction matches what is done in __init__.py by importing both _version.py and _git_hash.py
-    # use "normalized" semantic version string (a.k.a., dots)
+    # this construction matches what is done in __init__.py by importing
+    # both _version.py and _git_hash.py use "normalized" semantic version string (a.k.a., dots)
     __version__ = __version__+ '+' + git_hash
     with open( os.path.join( pkg_dir, '_git_hash.py' ), 'w+' ) as f:
 	f.write( "__git_hash__ = '{0}'\n".format( git_hash) )

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ try:
     print "git hash " + git_hash
     # this construction matches what is done in __init__.py by importing both _version.py and _git_hash.py
     # use "normalized" semantic version string (a.k.a., dots)
-    __version__ = __version__+ '.' + git_hash
+    __version__ = __version__+ '+' + git_hash
     with open( os.path.join( pkg_dir, '_git_hash.py' ), 'w+' ) as f:
 	f.write( "__git_hash__ = '{0}'\n".format( git_hash) )
 except:

--- a/tests/pywndcharm_tests/test_PyImageMatrix.py
+++ b/tests/pywndcharm_tests/test_PyImageMatrix.py
@@ -39,6 +39,11 @@ from shutil import rmtree
 from numpy.testing import assert_equal
 
 import numpy as np
+
+import matplotlib
+# Need following line to generate images on servers, see
+# http://matplotlib.org/faq/howto_faq.html#generate-images-without-having-a-window-appear
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
 pychrm_test_dir = dirname( realpath( __file__ ) ) #WNDCHARM_HOME/tests/pywndchrm_tests

--- a/tests/pywndcharm_tests/test_visualization.py
+++ b/tests/pywndcharm_tests/test_visualization.py
@@ -1,27 +1,26 @@
-"""
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                                                                               
- Copyright (C) 2015 National Institutes of Health 
-
-    This library is free software; you can redistribute it and/or              
-    modify it under the terms of the GNU Lesser General Public                 
-    License as published by the Free Software Foundation; either               
-    version 2.1 of the License, or (at your option) any later version.         
-                                                                               
-    This library is distributed in the hope that it will be useful,            
-    but WITHOUT ANY WARRANTY; without even the implied warranty of             
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU          
-    Lesser General Public License for more details.                            
-                                                                               
-    You should have received a copy of the GNU Lesser General Public           
-    License along with this library; if not, write to the Free Software        
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA  
-                                                                               
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                                                                               
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- Written by:  Christopher Coletta (github.com/colettace)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Copyright (C) 2015 National Institutes of Health
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Written by:  Christopher Coletta (github.com/colettace)
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 import sys
 if sys.version_info < (2, 7):
@@ -47,6 +46,7 @@ from wndcharm.FeatureSpacePredictionExperiment import FeatureSpaceClassification
 from wndcharm.visualization import PredictedValuesGraph, AccuracyVersusNumFeaturesGraph
 try:
     import matplotlib
+    matplotlib.use('Agg')
     HasMatplotlib = True
 except ImportError:
     HasMatplotlib = False

--- a/wndcharm/__init__.py
+++ b/wndcharm/__init__.py
@@ -1,27 +1,26 @@
-"""
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                                                                               
- Copyright (C) 2015 National Institutes of Health 
-
-    This library is free software; you can redistribute it and/or              
-    modify it under the terms of the GNU Lesser General Public                 
-    License as published by the Free Software Foundation; either               
-    version 2.1 of the License, or (at your option) any later version.         
-                                                                               
-    This library is distributed in the hope that it will be useful,            
-    but WITHOUT ANY WARRANTY; without even the implied warranty of             
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU          
-    Lesser General Public License for more details.                            
-                                                                               
-    You should have received a copy of the GNU Lesser General Public           
-    License along with this library; if not, write to the Free Software        
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA  
-                                                                               
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                                                                               
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- Written by:  Christopher Coletta (github.com/colettace)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Copyright (C) 2015 National Institutes of Health 
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Written by:  Christopher Coletta (github.com/colettace)
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 __version__ = "unknown"
 
@@ -34,10 +33,9 @@ except ImportError:
     pass
 
 try:
-    from _svn_version import __svn_version__
-    __version__ = __version__+'-'+__svn_version__
-except ImportError:
-    # We're running in a tree that doesn't have a _svn_version.py, so we don't know what our version is.
+    from _git_hash import __git_hash__
+    __version__ = __version__+ '.' + __git_hash__
+except:
     pass
 
 

--- a/wndcharm/__init__.py
+++ b/wndcharm/__init__.py
@@ -38,6 +38,51 @@ try:
 except:
     pass
 
+class _package_versions( object ):
+    """Report the versions of various Python packages WND-CHARM
+    depends on/is often used with"""
+
+    def __init__( self ):
+        self.module_list = ['wndcharm', 'numpy', 'scipy', 'matplotlib', 'sklearn', \
+                'IPython', 'tifffile', 'PIL', 'pandas']
+
+    def get_package_versions( self ):
+        """Runs through self.module_list, tries to import,
+        then gets .__version__ or .VERSION"""
+
+        ret = []
+        import sys
+        ret.append( ('python', sys.version ) )
+
+        for name in self.module_list:
+            m = None
+            ver = None
+            try: # 1. can we import it?
+                m = __import__( name )
+                try: #2. does it have a __version__?
+                    ver = m.__version__
+                except AttributeError:
+                    try: # 3. Is it PIL which has a .VERSION instead?
+                        ver = m.VERSION
+                    except AttributeError:
+                        ver = 'version not available'
+            except ImportError:
+                pass
+
+            ret.append( ( name, ver ) )
+        return ret
+
+    def __call__( self ):
+        return self.get_package_versions()
+
+    def __str__( self ):
+        retval = self.get_package_versions()
+        outstr = ""
+        for name, ver in retval:
+            outstr += str( name ) + ': ' + str( ver ) + '\n'
+        return outstr
+
+package_versions = _package_versions()
 
 # The numbers *must* be consistent with what's defined in wndchrm C-codebase.
 feature_vector_major_version = 3

--- a/wndcharm/__init__.py
+++ b/wndcharm/__init__.py
@@ -34,7 +34,7 @@ except ImportError:
 
 try:
     from _git_hash import __git_hash__
-    __version__ = __version__+ '.' + __git_hash__
+    __version__ = __version__+ '+' + __git_hash__
 except:
     pass
 

--- a/wndcharm/visualization.py
+++ b/wndcharm/visualization.py
@@ -1,28 +1,26 @@
-"""
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                                                                               
- Copyright (C) 2015 National Institutes of Health 
-
-    This library is free software; you can redistribute it and/or              
-    modify it under the terms of the GNU Lesser General Public                 
-    License as published by the Free Software Foundation; either               
-    version 2.1 of the License, or (at your option) any later version.         
-                                                                               
-    This library is distributed in the hope that it will be useful,            
-    but WITHOUT ANY WARRANTY; without even the implied warranty of             
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU          
-    Lesser General Public License for more details.                            
-                                                                               
-    You should have received a copy of the GNU Lesser General Public           
-    License along with this library; if not, write to the Free Software        
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA  
-                                                                               
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                                                                               
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- Written by:  Christopher Coletta (github.com/colettace)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
-
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Copyright (C) 2015 National Institutes of Health
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Written by:  Christopher Coletta (github.com/colettace)
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 import numpy as np
 from .utils import output_railroad_switch
@@ -127,10 +125,6 @@ class PredictedValuesGraph( _BaseGraph ):
         
         Required the package matplotlib to be installed."""
 
-        import matplotlib
-        # Need following line to generate images on servers, see
-        # http://matplotlib.org/faq/howto_faq.html#generate-images-without-having-a-window-appear
-        matplotlib.use('Agg')
         import matplotlib.pyplot as plt
 
         self.figure = plt.figure( figsize=self.figsize )
@@ -166,8 +160,6 @@ class PredictedValuesGraph( _BaseGraph ):
 
         bw_method - passed directly to bw_method arg in scipy.stats.gaussian_kde"""
 
-        import matplotlib
-        matplotlib.use('Agg')
         import matplotlib.pyplot as plt
 
         self.figure = plt.figure( figsize=self.figsize )
@@ -250,8 +242,6 @@ class FeatureTimingVersusAccuracyGraph( _BaseGraph ):
             split_result.Print()
             experiment.individual_results.append( split_result )
 
-        import matplotlib
-        matplotlib.use('Agg')
         import matplotlib.pyplot as plt
 
         x_vals = list( range( 1, max_num_features + 1 ) )
@@ -337,8 +327,6 @@ class AccuracyVersusNumFeaturesGraph( _BaseGraph ):
         y_max += horiz_buffer
         total_n_feats = kwargs['feature_space'].num_features
 
-        import matplotlib
-        matplotlib.use('Agg')
         import matplotlib.pyplot as plt
 
         self.figure = plt.figure( figsize=figsize, facecolor='white' )


### PR DESCRIPTION
* If Python API is built from repo, will include git commit hash in version string. If detects local modifications, will append "localmod" to version string+hash. If not built from a repo (e.g. release or github tarball) the version string is naked like before
* Easier query of environment: "from wndcharm import package_versions; print package_versions" gives the version of python, wndcharm, wndcharm dependencies, as well as other non-dependent 3rd party package I often use in conjunction with wndcharm
* Cleaned up unittest error that seemed to manifest itself on linux only