### PR TITLE
Adding a docker option to run wnd-charm

### DIFF
--- a/docker.README.md
+++ b/docker.README.md
@@ -1,0 +1,44 @@
+Development with Docker
+===
+[Docker](https://www.docker.com/) to run, test, and debug our application.
+The following documents how to install and use Docker on a Mac. There are
+[instructions](https://docs.docker.com/installation) for installing and using
+docker on other operating systems.
+
+On the mac, we use [docker for mac](https://docs.docker.com/engine/installation/mac/#/docker-for-mac).
+
+Table of Contents
+===
+* [Docker and WNDCHARM](#Docker-and-WNDCHARM)
+
+Docker and WNDCHARM
+===
+In the [docker](./docker) file in this repo, we've included the necessary
+files to compile and build a docker container that exposes wnd-charm using
+[Jupyterhub](https://github.com/jupyterhub/jupyterhub) and
+[Jupyterlab](https://github.com/jupyterlab/jupyterlab).
+
+Build the image
+-----
+From the parent folder of this repo:
+```
+docker build -t jupyterhub/wndcharm ./docker/.
+```
+Using the image
+-----
+Once the image is built, create a container:
+```
+docker run --name wndcharm -d -p 8000:8000 jupyterhub/wndcharm
+
+docker exec -it wndcharm bash
+passwd newuser
+```
+An interactive prompt will now open, choose a passwd for the newuser. After entering the password and confirming, you can exit the interactive session:
+```
+exit
+```
+wndcharm is now available for use at: http://localhost:8000. After logging in using `newuser` and the password entered above, choose `Notebook` and then choose the `Python 2` kernel when prompted (**not `Python 3`**). In the notebook you can run the following code to see the environment setup:
+```
+from wndcharm import diagnostics
+print diagnostics
+```

--- a/docker.README.md
+++ b/docker.README.md
@@ -1,7 +1,6 @@
 Development with Docker
 ===
-This document contains instructions on setting up a [Docker](https://www.docker.com/) container that contains a compiled version of wnd-charm and other
-recommended python packages.
+This document contains instructions illustrating how to set up a [Docker](https://www.docker.com/) image that contains a compiled version of wnd-charm and other recommended python packages.
 
 Table of Contents
 ===

--- a/docker.README.md
+++ b/docker.README.md
@@ -31,7 +31,7 @@ An interactive prompt will now open, choose a passwd for the newuser. After ente
 ```
 exit
 ```
-wndcharm is now available for use at: http://localhost:8000. After logging in using `newuser` and the password entered above, choose `Notebook` and then choose the `Python 2` kernel when prompted (**not `Python 3`**). In the notebook you can run the following code to see the environment setup:
+wndcharm is now available for use at: [http://localhost:8000](http://localhost:8000). After logging in using `newuser` and the password entered above, choose `Notebook` and then choose the `Python 2` kernel when prompted (**not `Python 3`**). In the notebook you can run the following code to see the environment setup:
 ```
 from wndcharm import diagnostics
 print diagnostics

--- a/docker.README.md
+++ b/docker.README.md
@@ -1,11 +1,7 @@
 Development with Docker
 ===
-[Docker](https://www.docker.com/) to run, test, and debug our application.
-The following documents how to install and use Docker on a Mac. There are
-[instructions](https://docs.docker.com/installation) for installing and using
-docker on other operating systems.
-
-On the mac, we use [docker for mac](https://docs.docker.com/engine/installation/mac/#/docker-for-mac).
+This document contains instructions on setting up a [Docker](https://www.docker.com/) container that contains a compiled version of wnd-charm and other
+recommended python packages.
 
 Table of Contents
 ===
@@ -13,8 +9,7 @@ Table of Contents
 
 Docker and WNDCHARM
 ===
-In the [docker](./docker) file in this repo, we've included the necessary
-files to compile and build a docker container that exposes wnd-charm using
+In the [docker](./docker) folder `Dockerfile` that compiles and provides and interface to wnd-charm through
 [Jupyterhub](https://github.com/jupyterhub/jupyterhub) and
 [Jupyterlab](https://github.com/jupyterlab/jupyterlab).
 

--- a/docker.README.md
+++ b/docker.README.md
@@ -8,7 +8,7 @@ Table of Contents
 
 Docker and WNDCHARM
 ===
-In the [docker](./docker) folder `Dockerfile` that compiles and provides and interface to wnd-charm through
+In the [docker](./docker) folder, there is a `Dockerfile` that compiles and provides and interface to wnd-charm through
 [Jupyterhub](https://github.com/jupyterhub/jupyterhub) and
 [Jupyterlab](https://github.com/jupyterlab/jupyterlab).
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,40 @@
+FROM jupyterhub/jupyterhub
+MAINTAINER Ben Neely <nigelneely@gmail.com>
+
+# install node.js and npm
+RUN apt-get -qq update && apt-get install -y \
+  git \
+  vim \
+  build-essential \
+  libtiff5-dev \
+  libfftw3-dev \
+  automake \
+  python-dev \
+  python-setuptools \
+  python-numpy \
+  python-scipy \
+  python-matplotlib \
+  python-tifffile \
+  python-pandas \
+  python-sklearn \
+  python-skimage \
+  swig
+
+RUN git clone https://github.com/wnd-charm/wnd-charm.git /wnd-charm
+RUN cd /wnd-charm && ./configure && touch * && make && make install
+
+RUN cd /wnd-charm && /usr/bin/python2.7 setup.py build
+RUN cd /wnd-charm && /usr/bin/python2.7 setup.py install
+RUN apt-get install -y python-pip
+
+RUN /usr/bin/python2.7 -c "import pip; pip.main(['install','ipykernel'])"
+RUN /usr/bin/python2.7 -m ipykernel install
+
+RUN pip install jupyter
+RUN pip install jupyterlab
+RUN jupyter serverextension enable --py jupyterlab --sys-prefix
+RUN useradd -ms /bin/bash newuser
+#add password
+#ensure home folder is accessible to jupyterhub
+
+ADD jupyterhub_config.py /srv/jupyterhub/jupyterhub_config.py

--- a/docker/jupyterhub_config.py
+++ b/docker/jupyterhub_config.py
@@ -1,2 +1,1 @@
 c.Spawner.default_url = '/lab'
-c.Authenticator.admin_users = {'nn31','huang008'}

--- a/docker/jupyterhub_config.py
+++ b/docker/jupyterhub_config.py
@@ -1,0 +1,2 @@
+c.Spawner.default_url = '/lab'
+c.Authenticator.admin_users = {'nn31','huang008'}


### PR DESCRIPTION
While trying to install wnd-charm for the first time, I ran into issue #78 (I primarily use anaconda on my laptop). For my team, I thought it would be nice to have a docker version available that would save them the time of compiling and provide a nice interface (i.e. Jupyterlab) so they could get started using wnd-charm right away. Hoping this might be useful for others. 