### PR TITLE
Update WORMfile.cpp

### DIFF
--- a/src/wndchrm_src/WORMfile.cpp
+++ b/src/wndchrm_src/WORMfile.cpp
@@ -119,7 +119,7 @@ FILE *WORMfile::fp () {
 
 void WORMfile::finish (bool reopen) {
 
-	if (_fp < 0) return;
+	if (_fp < (void*)0) return;
 
 	if (status == WORM_WR) {
 		// Change to read-only permissions


### PR DESCRIPTION
Resolved filetype error on macOS 10.14.5